### PR TITLE
Restructure the Code of Conduct

### DIFF
--- a/data/codeofconduct.md
+++ b/data/codeofconduct.md
@@ -1,38 +1,37 @@
 ## Introduction
 
-DACHFest is a community-driven conference for developers of all level of experience and background.
+DACHFest is a community-driven conference for developers of all experience levels and background.
 
 As a community-driven conference, we want everybody to feel welcome, regardless of gender, race, religion, sexual orientation, disabilites or physical appearance. We do not tolerate harassment of any kind.
 
-To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any DevFest Berlin event are required to conform to the following Code of Conduct. Organizers will enforce this code throughout the event.
+_Everyone_ (including speakers and staff) is required to conform to the following Code of Conduct. Organizers and volunteers will enforce this code throughout the event.
 
-The very short version of this Code of Conduct is "Don't be a dick". The following Code of Conduct explains what this means in detail.
+## Overview
 
-## The short version
+**Be kind to others.** We are all part of the same community, and everyone deserves to be here just as much as you, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or anything else. Be friendly and welcoming to others. Do not insult, harass or demean other people.
 
-All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate for any conference venue, including talks.
+**Be inclusive.** Keep in mind that your words, no matter how well-intentioned, can inadvertently hurt people who do not share your background or opinion. Sexual language and imagery is not appropriate, and so are sexist, racist, or exclusionary jokes. Try your best to avoid assumptions about other people's professions, roles, or skill levels.
 
-Be kind to others. Do not insult or put down other attendees. Behave professionally. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for DACHFest.
-
-If you notice that someone is being harassed, do not hesitate to contact the conference organizers or volunteers wearing a t-shirt with the word **"STAFF"** on it (or otherwise marked as staff) to report the incident. While we do our best to notice any case of harassment, we rely on your help as a coference attendee to report any incident.
-
-Attendees violating these rules may be asked to leave the conference without a refund at the sole discretion of the conference organizers.
+**Speak up.** If you or someone else are being harassed, do not hesitate to contact the event staff (organizers or volunteers), who can be identified by special badges or attire. While we do our best to notice any case of harassment, we rely on your help and would greatly appreciate it. If you feel uncomfortable to report a violation in person, please do so at **conduct@dachfest.com**.
 
 Thank you for helping make this a welcoming, friendly event for all.
 
-## The longer version
+## Details
 
 Participants asked to stop any harassing behavior are expected to comply immediately.
 
+Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, inappropriate physical contact, and unwelcome sexual attention.
+
 Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the anti-harassment policy. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
 
-Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for DACHFest.
+Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing is not appropriate for DACHFest either.
 
-If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.
+If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action they deem appropriate, including warning the offender or expelling the offender from the conference with no refund.
+
+The conference organizers will maintain the anonymity of the offended party, unless specifically discussed and agreed not to, as well as the anonymity of the alleged offender during an ongoing investigation.
 
 ## License
 
-This Code of Conduct was forked from the  [DevFest Berlin Code of Conduct](https://github.com/devfest-berlin/code-of-conduct/blob/master/code_of_conduct.md)  which is under a Creative Commons Attribution 3.0 Unported License.
+This Code of Conduct was forked from the [DevFest Berlin Code of Conduct](https://github.com/devfest-berlin/code-of-conduct/blob/master/code_of_conduct.md)  which is under a Creative Commons Attribution 3.0 Unported License.
 
-[![Creative Commons License](https://camo.githubusercontent.com/ea7febd364f01e7b3f46f6fb86712fe05925bfbf/687474703a2f2f692e6372656174697665636f6d6d6f6e732e6f72672f6c2f62792f332e302f38387833312e706e67)](http://creativecommons.org/licenses/by/3.0/)  
-Conference Code of Conduct by  [](https://us.pycon.org/2013/about/code-of-conduct/)[https://us.pycon.org/2013/about/code-of-conduct/](https://us.pycon.org/2013/about/code-of-conduct/)  is licensed under a  [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/).
+[![Creative Commons License](https://camo.githubusercontent.com/ea7febd364f01e7b3f46f6fb86712fe05925bfbf/687474703a2f2f692e6372656174697665636f6d6d6f6e732e6f72672f6c2f62792f332e302f38387833312e706e67)](http://creativecommons.org/licenses/by/3.0/)

--- a/data/codeofconduct.md
+++ b/data/codeofconduct.md
@@ -4,7 +4,7 @@ DACHFest is a community-driven conference for developers of all experience level
 
 As a community-driven conference, we want everybody to feel welcome, regardless of gender, race, religion, sexual orientation, disabilites or physical appearance. We do not tolerate harassment of any kind.
 
-_Everyone_ (including speakers and staff) is required to conform to the following Code of Conduct. Organizers and volunteers will enforce this code throughout the event.
+_Everyone_ (including speakers, sponsors, and staff) is required to conform to the following Code of Conduct. Organizers and volunteers will enforce this code throughout the event.
 
 ## Overview
 

--- a/data/codeofconduct.md
+++ b/data/codeofconduct.md
@@ -26,7 +26,7 @@ Exhibitors in the expo hall, sponsor or vendor booths, or similar activities are
 
 Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing is not appropriate for DACHFest either.
 
-If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action they deem appropriate, including warning the offender or expelling the offender from the conference with no refund.
+If a participant engages in behavior that violates this code of conduct, the conference organizers may take any action they deem appropriate, including expelling the offender from the conference with no refund.
 
 The conference organizers will maintain the anonymity of the offended party, unless specifically discussed and agreed not to, as well as the anonymity of the alleged offender during an ongoing investigation.
 


### PR DESCRIPTION
1. Made the short version shorter :)
2. Did some minor restructuring (the diff looks more messy than it is).
3. Added an email point of contact for people who don't want to report in person.
4. Added a statement about anonymity.
5. Added an explanation of what harassment is.

Tried to keep it readable, especially the overview part.

A suggestion from me personally would be to have people responsible for gathering reports and investigating, and to clearly state who those people are instead of giving a single email address without even mentioning who would be the person (or people) checking it. It would give the attendees more visibility into the process and help with trust.