### PR TITLE
Removed "how it was" part of about-block

### DIFF
--- a/src/elements/about-block.html
+++ b/src/elements/about-block.html
@@ -86,18 +86,6 @@
             </paper-button>
           </a>
 
-          <p>{$ aboutBlock.callToAction.howItWas.description $}</p>
-          <paper-button
-            class="animated icon-right"
-            on-tap="_playVideo"
-            ga-on="click"
-            ga-event-category="video"
-            ga-event-action="watch"
-            ga-event-label="about block - {$ aboutBlock.callToAction.howItWas.label $}"
-          >
-            <span>{$  aboutBlock.callToAction.howItWas.label $}</span>
-            <iron-icon icon="hoverboard:arrow-right-circle"></iron-icon>
-          </paper-button>
         </div>
 
         <div class="statistics-block">


### PR DESCRIPTION
We have an unnamed button on the about-block which does ... nothing.
![image](https://user-images.githubusercontent.com/1159449/42212399-457d3444-7eb6-11e8-86b2-980390106b18.png)

This PR removes this button from the template. Originally it was used to show a video from last year (which we don't have).