### PR TITLE
Adjusted viewport of logos

### DIFF
--- a/images/logo-monochrome.svg
+++ b/images/logo-monochrome.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 691.4 448" style="enable-background:new 0 0 691.4 448;" xml:space="preserve">
+	 viewBox="80 140 591.4 168" style="enable-background:new 80 140 591.4 168;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:none;}
 	.st1{fill:#686868;stroke:#FFFFFF;stroke-miterlimit:10;}

--- a/images/logo.svg
+++ b/images/logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 22.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_4" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-	 viewBox="0 0 691.4 448"  >
+	 viewBox="80 140 591.4 168"  >
 <style type="text/css">
 	.st0{fill:none;}
 	.st1{fill:#FFC107;}

--- a/src/elements/header-toolbar.html
+++ b/src/elements/header-toolbar.html
@@ -41,7 +41,7 @@
       .toolbar-logo {
         display: block;
         width: 150px;
-        height: 85px;
+        height: 32px;
         background-color: var(--default-primary-color);
         transition: background-color var(--animation);
         -webkit-mask: url('/images/logo-monochrome.svg') no-repeat;

--- a/src/hoverboard-app.html
+++ b/src/hoverboard-app.html
@@ -94,7 +94,7 @@
       }
 
       .toolbar-logo {
-        --iron-image-height: 85px;
+        --iron-image-height: 32px;
       }
 
       app-header-layout {


### PR DESCRIPTION
Originally the logos had quite some whitespace which is probably the reason why @mfahlandt originally increased the top navigation bar height.

In this PR I remove most of the logos whitespace, and reverted height of the top navigation bar to its original value.
The purpose is to fix issue #12 