### PR TITLE
Replaced "Musterfirma"

### DIFF
--- a/src/pages/privacy.html
+++ b/src/pages/privacy.html
@@ -121,13 +121,14 @@
                         <p>I. Information about us as controllers of your data<br>II. The rights of users and data subjects<br>III. Information about the data processing</p>
                         <h3>I. Information about us as controllers of your data</h3>
                         <p>The party responsible for this website (the "controller") for purposes of data protection law is:</p>
-                        <p><span style="color: #ff0000;">Sample company/entrepreneur</span><br><span style="color: #ff0000;">Any street 1</span><br><span style="color: #ff0000;">12345 Anytown</span><br><span style="color: #ff0000;">Germany</span></p>
-                        <p><span style="color: #ff0000;">Telephone: Telephone number</span><br><span style="color: #ff0000;">Fax: Fax number</span><br><span style="color: #ff0000;">Email: muster@mustermail.xy</span></p>
+                        <p>Verein "GDG Vienna"<br>
+                            Schopenhauerstr. 64<br>
+                            1180 Vienna<br>
+                            Austria</p>
+                        <p>Telephone: +4369911233832<br>
+                            Email: team@gdg-vienna.at</p>
                         <p>The controller's data protection officer is:</p>
-                        <p><span style="color: #ff0000;">Maxie Musterfrau&nbsp;</span></p>
-                        <p><span style="color: #ff0000;">[The following information must be added if an external data protection officer has been appointed].</span></p>
-                        <p><span style="color: #ff0000;">Any street 1</span><br><span style="color: #ff0000;">12345 Anytown</span><br><span style="color: #ff0000;">Germany</span></p>
-                        <p><span style="color: #ff0000;">Telephone: Telephone number</span><br><span style="color: #ff0000;">Fax: Fax number</span><br><span style="color: #ff0000;">Email: datenschutz@mustermail.xy</span></p>
+                        <p>Helmuth Breitenfellner&nbsp;</p>
                         <h3>II. The rights of users and data subjects</h3>
                         <p>With regard to the data processing to be described in more detail below, users and data subjects have the right</p>
                         <ul type="disc">
@@ -243,7 +244,7 @@
                         <p>The legal basis for sending the newsletter and the analysis is Art. 6 Para. 1 lit. a) GDPR.</p>
                         <p>You may revoke your prior consent to receive this newsletter under Art. 7 Para. 3 GDPR with future effect. All you have to do is inform us that you are revoking your consent or click on the unsubscribe link contained in each newsletter.</p>
 
-                        <p><a href="https://www.ratgeberrecht.eu/leistungen/muster-datenschutzerklaerung.html" target="_blank" rel="noopener">Model Data Protection Statement</a> for <a href="https://www.ratgeberrecht.eu/" target="_blank">Anwaltskanzlei Weiß &amp; Partner</a></p>
+                        <p><a href="https://www.ratgeberrecht.eu/leistungen/muster-datenschutzerklaerung.html" target="_blank" rel="noopener">Model Data Protection Statement</a> created by <a href="https://www.ratgeberrecht.eu/" target="_blank">Anwaltskanzlei Weiß &amp; Partner</a></p>
                     </div>
 
             </div>


### PR DESCRIPTION
Our privacy page needs some updates. It refers to "Musterfirma".

Feel free to replace it with whoever's address / name you prefer here.