### PR TITLE
Replace Lviv with GDG DACH on team page

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -168,7 +168,7 @@
     "toast": "Successfully subscribed!"
   },
   "team": {
-    "description": "Google is known all around the world. Everyone is 'googling', checking on 'maps' and communicating in 'gmail'. For simple users, they are services that just works, but not for us. Developers see much more: APIs, scalability issues, complex technology stacks. And that is what GDG is about.<br><br> [Google Developers Group (GDG) Lviv](http://lviv.gdg.org.ua/) - is open and volunteer geek community who create exciting projects and share experience about Google technologies with a passion.<br><br> Our goal is to organize space to connect the best industry experts with Ukrainian audience to boost development of IT."
+    "description": "Google is known all around the world. Everyone is 'googling', checking on 'maps' and communicating in 'gmail'. For simple users, they are services that just works, but not for us. Developers see much more: APIs, scalability issues, complex technology stacks. And that is what GDG is about.<br><br>Google Developer Groups (GDG) in Germany, Austria and Switzerland come together to create exciting projects and share experience about Google technologies with a passion.<br><br> Our goal is to organize space to connect the best industry experts with audience in the region to boost development of IT."
   },
   "schedule": {
     "saveSessionsSignedOut": "Sign in to save sessions"


### PR DESCRIPTION
There is some text on the team page talking about GDG Lviv - I have replaced it with some dummy text about GDGs in the DACH region.

You find the old text on https://www.dachfest.com/team and it should be replaced soonish...